### PR TITLE
chore(deps): Update nodejs 16 in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ inputs:
     default: Jest Test Results
 
 runs:
-  using: node12
+  using: node16
   main: dist/index.js


### PR DESCRIPTION
This update is needed as node 12 is deprecated

Running the action currently gives the following warning:
```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: tanmen/jest-reporter
```